### PR TITLE
Resolved #1: Fix version conflicts of random_compat2 in PHP5.6&PHP7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": ">=2.0"
     },
     "require-dev": {
         "phpunit/phpunit" : ">=5.6",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix version conflicts of random_compat2 in PHP5.6&PHP7.

## Motivation and context

Fixes #1 

