### PR TITLE
Resolved #3: Make the $size parameter be optional of method Client::generateId(...);

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -36,10 +36,10 @@ class Client
      */
     public function __construct($size = 21, GeneratorInterface $generator = null)
     {
-        $this->alphbet = '_~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $this->size = $size > 0 ? $size : 21;
         $this->generator = $generator?:new Generator();
         $this->core = new Core();
+        $this->alphbet = CoreInterface::SAFE_SYMBOLS;
     }
 
     /**
@@ -49,9 +49,9 @@ class Client
      * @param integer $mode Client::MODE_NORMAL|Client::MODE_DYNAMIC
      * @return string
      */
-    public function generateId($size, $mode = self::MODE_NORMAL)
+    public function generateId($size = 0, $mode = self::MODE_NORMAL)
     {
-        $size = $size?: $this->size;
+        $size = $size>0? $size: $this->size;
         switch ($mode) {
             case self::MODE_DYNAMIC:
                 return $this->core->random($this->generator, $size);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -20,6 +20,8 @@ class ClientTest extends TestCase
         $dynamicRandom = $client->generateId($size, Client::MODE_DYNAMIC);
         $this->assertEquals($size, strlen($dynamicRandom));
         $this->assertNotEquals($normalRandom, $dynamicRandom);
+        $defaultRandom = $client->generateId();
+        $this->assertEquals(21, strlen($defaultRandom));
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Resolve #3 generateID should use Client settings as default

## Motivation and context

Make the `$size` parameter be optional of method `Client::generateId($size
= 0, $mode = self::MODE_NORMAL);`
Default value was take from Client instance property `$size`

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

