### PR TITLE
update method name, keep old for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ echo $client->generateId($size = 21, $mode = Client::MODE_DYNAMIC)
 ### Custom Alphabet or Length
 
 ``` php
-echo $client->formatedId($alphabet = '0123456789abcdefg', $size = 21);
+echo $client->formattedId($alphabet = '0123456789abcdefg', $size = 21);
 ```
 
 > Alphabet must contain 256 symbols or less.
@@ -52,7 +52,7 @@ echo $client->formatedId($alphabet = '0123456789abcdefg', $size = 21);
 
 ``` php
 # PS: anonymous class is new feature when PHP_VERSION >= 7.0
-echo $client->formatedId($alphabet = '0123456789abcdefg', $size = 21,
+echo $client->formattedId($alphabet = '0123456789abcdefg', $size = 21,
 new class implements GeneratorInterface {
     /**
      * @inheritDoc

--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -10,7 +10,7 @@ $counter = [];
 
 $timeStated = microtime(true);
 for ($i = 0; $i < $loop; $i++) {
-    $alpha = $nano->formatedId($alphabet, 1);
+    $alpha = $nano->formattedId($alphabet, 1);
     !isset($counter[$alpha]) and $counter[$alpha] = 0;
     isset($counter[$alpha]) and $counter[$alpha]++;
 }

--- a/examples/custom_formated.php
+++ b/examples/custom_formated.php
@@ -22,8 +22,8 @@ class DummyGenerator implements GeneratorInterface
 
 $nano = new Client();
 $alphabet = '0123456789';
-$nanoId = $nano->formatedId($alphabet, 10);
-$dummyId = $nano->formatedId($alphabet, 10, new DummyGenerator);
+$nanoId = $nano->formattedId($alphabet, 10);
+$dummyId = $nano->formattedId($alphabet, 10, new DummyGenerator);
 
 printf("Default nano ID: %s\n", $nanoId);
-printf("Formated nano ID: %s\n", $dummyId);
+printf("Formatted nano ID: %s\n", $dummyId);

--- a/src/Client.php
+++ b/src/Client.php
@@ -90,7 +90,8 @@ class Client
      * @return string
      * @since 1.0.0
      */
-    public function formatedId($alphabet, $size, GeneratorInterface $generator = null) {
+    public function formatedId($alphabet, $size, GeneratorInterface $generator = null)
+    {
         return $this->formattedId($alphabet, $size, $generator);
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -72,12 +72,26 @@ class Client
      * @param string $alphabet default CoreInterface::SAFE_SYMBOLS
      * @return string
      */
-    public function formatedId($alphabet, $size, GeneratorInterface $generator = null)
+    public function formattedId($alphabet, $size, GeneratorInterface $generator = null)
     {
         $generator = $generator?:$this->generator;
         $alphabet = $alphabet?:CoreInterface::SAFE_SYMBOLS;
 
         return $this->core->random($generator, $size, $alphabet);
+    }
+
+    /**
+     * Backwards-compatible method name.
+     *
+     * @param string $alphabet
+     * @param integer $size
+     * @param GeneratorInterface $generator
+     *
+     * @return string
+     * @since 1.0.0
+     */
+    public function formatedId($alphabet, $size, GeneratorInterface $generator = null) {
+        return $this->formattedId($alphabet, $size, $generator);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -29,13 +29,13 @@ class ClientTest extends TestCase
      * @dataProvider clientProvider
      * @param Client $client
      */
-    public function testFormatedId(Client $client)
+    public function testFormattedId(Client $client)
     {
         $size = 10;
         $alphabet = '0123456789abcdefghi';
-        $id = $client->formatedId($alphabet, $size);
+        $id = $client->formattedId($alphabet, $size);
         $this->assertEquals($size, strlen($id));
-        $dummyId = $client->formatedId($alphabet, $size, new DummyGenerator);
+        $dummyId = $client->formattedId($alphabet, $size, new DummyGenerator);
         $this->assertEquals($size, strlen($dummyId));
         $this->assertNotEquals($id, $dummyId);
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -41,6 +41,22 @@ class ClientTest extends TestCase
     }
 
     /**
+     * @group passed
+     * @dataProvider clientProvider
+     * @param Client $client
+     */
+    public function testFormatedId(Client $client)
+    {
+        $size = 10;
+        $alphabet = '0123456789abcdefghi';
+        $id = $client->formatedId($alphabet, $size);
+        $this->assertEquals($size, strlen($id));
+        $dummyId = $client->formatedId($alphabet, $size, new DummyGenerator);
+        $this->assertEquals($size, strlen($dummyId));
+        $this->assertNotEquals($id, $dummyId);
+    }
+
+    /**
      * Client Provider
      *
      * @return mixed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I updated a method name and retained the old one for backwards-compatibility.

## Motivation and context

This fixes the English spelling of `$client->formatedId()` to `$client->formattedId()`.
## How has this been tested?

Ran PHP in interactive mode and tested both `$client->formatedId()` and `$client->formattedId()` to verify they worked.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
