### PR TITLE
add missing default params in formattedId()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -37,7 +37,7 @@ class Client
     public function __construct($size = 21, GeneratorInterface $generator = null)
     {
         $this->size = $size > 0 ? $size : 21;
-        $this->generator = $generator?:new Generator();
+        $this->generator = $generator ?: new Generator();
         $this->core = new Core();
         $this->alphbet = CoreInterface::SAFE_SYMBOLS;
     }
@@ -51,10 +51,11 @@ class Client
      */
     public function generateId($size = 0, $mode = self::MODE_NORMAL)
     {
-        $size = $size>0? $size: $this->size;
+        $size = $size > 0 ? $size : $this->size;
+
         switch ($mode) {
             case self::MODE_DYNAMIC:
-                return $this->core->random($this->generator, $size);
+                return $this->core->random($this->generator, $size, $this->alphbet);
             default:
                 return $this->normalRandom($size);
         }
@@ -67,15 +68,16 @@ class Client
      *
      * @see https://github.com/ai/nanoid/blob/master/format.js
      * @see https://github.com/ai/nanoid/blob/master/generate.js
-     * @param GeneratorInterface $generator
-     * @param integer $size
      * @param string $alphabet default CoreInterface::SAFE_SYMBOLS
+     * @param integer $size
+     * @param GeneratorInterface $generator
      * @return string
      */
-    public function formattedId($alphabet, $size, GeneratorInterface $generator = null)
+    public function formattedId($alphabet = null, $size = 0, GeneratorInterface $generator = null)
     {
-        $generator = $generator?:$this->generator;
-        $alphabet = $alphabet?:CoreInterface::SAFE_SYMBOLS;
+        $alphabet = $alphabet ?: CoreInterface::SAFE_SYMBOLS;
+        $size = $size > 0 ? $size : $this->size;
+        $generator = $generator ?: $this->generator;
 
         return $this->core->random($generator, $size, $alphabet);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some really basic things are wrong, as far as I know:
The `formattedId()` method was missing default params, so I added `$alphabet = null` and `$size = 0`.
Also `generateId()` was calling `random()` without $alphabet, so I also added it.

## Motivation and context

Not shure how how nobody noticed this... if the client is instantiated with a size:
```php
$client = new Client(6);
```

and then do this:
```php
$id = $client->formattedId($alphabet);
```

An exception is thrown because $size is missing:
```php
Too few arguments to function Hidehalo\Nanoid\Client::formattedId()
```

Why? I already set the $size in the client.

Same thing in `generateId()`, $alphabet is not passed to `random()` even if I already defined it.
```php
$this->core->random($this->generator, $size);
```

## How has this been tested?

With care and attention to basic things.

## Screenshots (if appropriate)
?

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
I'm sure this is super important but I'm just trying to help and I have not idea what this checklist is about: **exactly one patch**, **individual commit**, **branch for this patch** and so on...

Hope you can find the pull request useful.