### PR TITLE
typo: remove $ at begin composer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you like nanoid and you want to use it in PHP, try me :D
 Via Composer
 
 ``` bash
-$composer require hidehalo/nanoid-php
+composer require hidehalo/nanoid-php
 ```
 
 ## Usage
@@ -83,7 +83,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Testing
 
 ``` bash
-$composer test
+composer test
 ```
 
 ## Contributing


### PR DESCRIPTION
## Description
remove $ at begin composer command

## Motivation and context
github just release copy button on quote, if we have `$` when user using copy button, they have to manually remove `$`

![nanophp](https://user-images.githubusercontent.com/7130705/120262855-c0dcb380-c2c4-11eb-9cdd-a3191aa897a8.png)
