### PR TITLE
fix: Normal mode now generate random id correctly

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -109,8 +109,8 @@ class Client
     {
         $id = '';
         while (1 <= $size--) {
-            $rand = intval(mt_rand()/(mt_getrandmax() + 1));
-            $id .= $this->alphabet[$rand*64 | 0];
+            $rand = mt_rand()/(mt_getrandmax() + 1);
+            $id .= $this->alphabet[intval($rand*64)];
         }
 
         return $id;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -17,11 +17,13 @@ class ClientTest extends TestCase
         $size = 7;
         $normalRandom = $client->generateId($size);
         $this->assertEquals($size, strlen($normalRandom));
+        $this->assertNotEquals(str_repeat('_', $size), $normalRandom);
         $dynamicRandom = $client->generateId($size, Client::MODE_DYNAMIC);
         $this->assertEquals($size, strlen($dynamicRandom));
         $this->assertNotEquals($normalRandom, $dynamicRandom);
         $defaultRandom = $client->generateId();
         $this->assertEquals(21, strlen($defaultRandom));
+        $this->assertNotEquals(str_repeat('_', 21), $defaultRandom);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Should only explicit cast on random index for alphabet array.

## Motivation and context

To fix the bug caused by previous pull request #21 .

In the previous pull request, It outputs the result with only underscore(the first value of the alphabet array) as the explicit casted random number is always `0`

for example:
```php
use Hidehalo\Nanoid\Client;

$client = new Client();

$result = $client->generateId(10);
// $result = '__________'
```

## How has this been tested?

Added 2 new assertions to make ensure that it does not generate the result with only underscore.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

