### PR TITLE
Fix deprecation warnings thrown when used with PHP 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'macos-latest']
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         phpunit-versions: ['latest']
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0|~8.0",
+        "php": "~7.1|~8.0",
         "paragonie/random_compat": ">=2.0"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -34,9 +34,9 @@ class Client
      *
      * @codeCoverageIgnore
      * @param integer $size
-     * @param GeneratorInterface $generator
+     * @param GeneratorInterface|null $generator
      */
-    public function __construct($size = 21, GeneratorInterface $generator = null)
+    public function __construct($size = 21, ?GeneratorInterface $generator = null)
     {
         $this->size = $size > 0 ? $size : 21;
         $this->generator = $generator ?: new Generator();
@@ -67,12 +67,12 @@ class Client
      * you have been implements your custom GeneratorInterface as correctly.
      * Otherwise use the build-in default random bytes generator
      *
-     * @param GeneratorInterface $generator
+     * @param GeneratorInterface|null $generator
      * @param integer $size
      * @param string $alphabet default CoreInterface::SAFE_SYMBOLS
      * @return string
      */
-    public function formattedId($alphabet, $size = 0, GeneratorInterface $generator = null)
+    public function formattedId($alphabet, $size = 0, ?GeneratorInterface $generator = null)
     {
         $alphabet = $alphabet ?: CoreInterface::SAFE_SYMBOLS;
         $size = $size > 0 ? $size : $this->size;
@@ -86,12 +86,12 @@ class Client
      *
      * @param string $alphabet
      * @param integer $size
-     * @param GeneratorInterface $generator
+     * @param GeneratorInterface|null $generator
      *
      * @return string
      * @since 1.0.0
      */
-    public function formatedId($alphabet, $size = 0, GeneratorInterface $generator = null)
+    public function formatedId($alphabet, $size = 0, ?GeneratorInterface $generator = null)
     {
         $size = $size > 0 ? $size : $this->size;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes some warnings reported when used with PHP 8.4, due to the [deprecation of implicit nullability](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) for typed method arguments.

## Motivation and context

PHP 8.4 now warns when doing things like `GeneratorInterface $generator = null` instead of explicitly marking the argument as nullable: `?GeneratorInterface $generator = null`.

In PHP 9 this will throw an error.

> This issue was reported in https://github.com/hidehalo/nanoid-php/issues/31

## How has this been tested?

I checked the execution of PHPUnit does not print any warning when run in PHP 8.4

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Technically speaking, this is a bug fix, although, the approach used to solve the warning (mark arguments as nullable), requires to bump the minimum supported PHP version to 7.1

An alternative approach would be to remove the native type from arguments entirely, and rely on types defined in PHPDocs. That would allow to keep compatibility with all versions. I'm ok going in that direction if preferred. 
